### PR TITLE
add a new dedicated thread pool pipeline which can run async stages

### DIFF
--- a/test/papaline/core_test.clj
+++ b/test/papaline/core_test.clj
@@ -1,7 +1,9 @@
 (ns papaline.core-test
   (:require [clojure.test :refer :all]
             [clojure.core.async :refer [chan >!! <!! go timeout]]
-            [papaline.core :refer :all]))
+            [papaline.core :refer :all])
+  (:import (java.util.concurrent CompletableFuture)
+           (java.util.function Supplier)))
 
 (deftest test-stage
   (let [f (fn [arg])
@@ -34,10 +36,31 @@
         f (vec (take num (repeat (fn [c sync-chan] (swap! c inc) [c sync-chan]))))
         f (conj f (fn [c sync-chan] (>!! sync-chan 0)))
         stgs (map stage f)
-        ppl (dedicated-thread-pool-pipeline stgs executor)]
-    (run-pipeline ppl c0 sync-chan)
+        ppl (dedicated-thread-pool-pipeline stgs executor)
+        ret (run-pipeline ppl c0 sync-chan)]
+    ;(run-pipeline ppl c0 sync-chan)
     (<!! sync-chan)
-    (is (= num @c0))))
+    (is (= num @c0))
+    (is (= (.get ret) {:args true}))))
+
+(deftest test-run-async-threadpool-pipeline
+  (let [c0 (atom 0)
+        sync-chan (chan)
+        num 5
+        executor (make-thread-pool 2 2)
+        f (vec (take num (repeat (fn [c sync-chan]
+                                   (swap! c inc)
+                                   (CompletableFuture/supplyAsync (reify Supplier
+                                                                    (get [this]
+                                                                      (Thread/sleep 300)
+                                                                      [c sync-chan])))))))
+        f (conj f (fn [c sync-chan] (CompletableFuture/completedFuture (>!! sync-chan 0))))
+        stgs (map stage f)
+        ppl (async-dedicated-thread-pool-pipeline stgs executor)
+        ret (run-pipeline ppl c0 sync-chan)]
+    (<!! sync-chan)
+    (is (= num @c0))
+    (is (= (.get ret) {:args true}))))
 
 (deftest test-copy-stage
   (let [c0 (atom 0)
@@ -77,13 +100,26 @@
   (let [c0 (atom 0)
         stg0 (fn [c] (abort))
         stg1 (fn [c] (swap! c inc))
-        ppl (pipeline (map stage [stg0 stg1]))
-        ppl2 (dedicated-thread-pool-pipeline (map stage [stg0 stg1])
-                                            (make-thread-pool 2 2))]
+        normal-stgs (map stage [stg0 stg1])
+
+        async-stg0 (fn [c] (CompletableFuture/supplyAsync (reify Supplier (get [this] (abort)))))
+        async-stg1 (fn [c] (swap! c inc) (CompletableFuture/completedFuture "Done"))
+        async-stgs (map stage [async-stg0 async-stg1])
+
+        ppl (pipeline normal-stgs)
+        ppl2 (dedicated-thread-pool-pipeline normal-stgs (make-thread-pool 2 2))
+        ppl3 (async-dedicated-thread-pool-pipeline normal-stgs (make-thread-pool 2 2))
+        ppl4 (async-dedicated-thread-pool-pipeline async-stgs (make-thread-pool 2 2))]
     (run-pipeline-wait ppl c0)
     (is (= 0 @c0))
 
     (run-pipeline-wait ppl2 c0)
+    (is (= 0 @c0))
+
+    (run-pipeline-wait ppl3 c0)
+    (is (= 0 @c0))
+
+    (run-pipeline-wait ppl4 c0)
     (is (= 0 @c0))))
 
 (deftest test-abort-and-return
@@ -91,13 +127,27 @@
     (let [c0 (atom 0)
           stg0 (fn [c] (abort -1))
           stg1 (fn [c] (swap! c inc))
+          normal-stgs (map stage [stg0 stg1])
+
+          async-stg0 (fn [c] (CompletableFuture/supplyAsync (reify Supplier (get [this] (abort -1)))))
+          async-stg1 (fn [c] (swap! c inc) (CompletableFuture/completedFuture "Done"))
+          async-stgs (map stage [async-stg0 async-stg1])
+
           ppl (pipeline (map stage [stg0 stg1]))
           ppl2 (dedicated-thread-pool-pipeline (map stage [stg0 stg1])
-                                               (make-thread-pool 2 2))]
+                                               (make-thread-pool 2 2))
+          ppl3 (async-dedicated-thread-pool-pipeline normal-stgs (make-thread-pool 2 2))
+          ppl4 (async-dedicated-thread-pool-pipeline async-stgs (make-thread-pool 2 2))]
       (is (= -1 (run-pipeline-wait ppl c0)))
       (is (= 0 @c0))
 
       (is (= -1 (run-pipeline-wait ppl2 c0)))
+      (is (= 0 @c0))
+
+      (is (= -1 (run-pipeline-wait ppl3 c0)))
+      (is (= 0 @c0))
+
+      (is (= -1 (run-pipeline-wait ppl4 c0)))
       (is (= 0 @c0)))))
 
 (deftest test-fork-join
@@ -155,6 +205,19 @@
       (run-pipeline-wait p)
       (is (= 1 @mark)))))
 
+(deftest test-fork-join-in-async-dedicated-threadpool-pipeline
+  (testing "async dedicated thread pool doesn't accept (fork) and (join) result, error expected"
+    (let [mark (atom 0)
+          t    (make-thread-pool 2 2)
+          f    (named-stage "demo-stage-0" (fn [] (fork (range 10))))
+          p    (async-dedicated-thread-pool-pipeline [f] t
+                                                     :error-handler
+                                                     (fn [e]
+                                                       (is (instance? UnsupportedOperationException e))
+                                                       (swap! mark inc)))]
+      (run-pipeline-wait p)
+      (is (= 1 @mark)))))
+
 (deftest test-pre-post-hook-for-pipeline
   (testing "pre-hook and post-hook"
     (let [h0 (atom false)
@@ -200,6 +263,23 @@
         (<!! sync-chan)
         (is (= num @c0))
         (is (and @h0 @h1)))))
+  (testing "for async dedicated thread pool"
+    (let [h0 (atom false)
+          h1 (atom false)
+          c0 (atom 0)
+          sync-chan (chan)
+          num 5
+          executor (make-thread-pool 2 2)
+          f (vec (take num (repeat (fn [c sync-chan] (swap! c inc) [c sync-chan]))))
+          f (conj f (fn [c sync-chan] (>!! sync-chan 0)))
+          stgs (map stage f)
+          ppl (async-dedicated-thread-pool-pipeline stgs executor)]
+      (binding [*pre-execution-hook* (fn [_] (reset! h0 true))
+                *post-execution-hook* (fn [_] (reset! h1 true))]
+        (run-pipeline ppl c0 sync-chan)
+        (<!! sync-chan)
+        (is (= num @c0))
+        (is (and @h0 @h1)))))
   (testing "abort"
     (let [c0 (atom 0)
           h0 (atom 0)
@@ -208,7 +288,9 @@
           stg1 (fn [c] (swap! c inc))
           ppl (pipeline (map stage [stg0 stg1]))
           ppl2 (dedicated-thread-pool-pipeline (map stage [stg0 stg1])
-                                               (make-thread-pool 2 2))]
+                                               (make-thread-pool 2 2))
+          ppl3 (async-dedicated-thread-pool-pipeline (map stage [stg0 stg1])
+                                                     (make-thread-pool 2 2))]
       (binding [*pre-execution-hook* (fn [_] (swap! h0 inc))
                 *post-execution-hook* (fn [_] (swap! h1 inc))]
         (run-pipeline-wait ppl c0)
@@ -217,8 +299,11 @@
         (run-pipeline-wait ppl2 c0)
         (is (= 0 @c0))
 
-        (is (= 2 @h0))
-        (is (= 2 @h1)))))
+        (run-pipeline-wait ppl3 c0)
+        (is (= 0 @c0))
+
+        (is (= 3 @h0))
+        (is (= 3 @h1)))))
   (testing "error-handler"
     (let [h0 (atom false)
           h1 (atom false)


### PR DESCRIPTION
This PR added a new pipeline called AsyncDedicatedThreadPoolPipeline. It uses a dedicated thread pool to run stages like DedicatedThreadPoolPipeline. When it runs, it'll check the result type of every stage. If it found a stage returns a Future, it'll add a listener for this Future and release the thread back to pool. When the stage returns a Future is done, the listener for this Future will be called by another thread in the same dedicated thread pool and the pipeline can continue to run the remaining stages. 

For example, we have a pipeline which contains a stage fetching data from another website. Instead of block waiting for the response coming, the stage can set a callback and send it's request to fetch data then returns a Future. Then the thread can serve next request. When the response coming, another thread from dedicated thread pool will be waked up to finish remaining stages. 